### PR TITLE
Added cookbook name and version bump

### DIFF
--- a/cookbooks/tomcat7/metadata.rb
+++ b/cookbooks/tomcat7/metadata.rb
@@ -1,9 +1,10 @@
+name             'tomcat7'
 maintainer       "Vladislav Mikhaylov"
 maintainer_email "solarvm@gmail.com"
 license          "AGPL"
 description      "Installs/Configures tomcat7 binary distrib"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.3"
+version          "0.0.4"
 
 recipe "tomcat7::default", "Installs and configures Tomcat7"
 


### PR DESCRIPTION
Hello,

This pull request fixes cookbook dependency resolution using Berkshelf.

```
Fetching 'tomcat7' from https://github.com/jtalks-org/jtalks-vm.git (at master/cookbooks/tomcat7)
Ridley::Errors::MissingNameAttribute The metadata at '/var/folders/6w/gk5wvlvn13bd9g4vpk20yvrr0000gn/T/d20140408-47229-1tnf1cd' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.
```
